### PR TITLE
perf: replace useState with useReducer

### DIFF
--- a/src/use-force-update.ts
+++ b/src/use-force-update.ts
@@ -1,13 +1,14 @@
 import { useReducer } from 'react';
 
-type VoidFunction = () => void
+type VoidFunction = () => void;
 type VoidFunctionCreator = () => VoidFunction;
 type ToggleReducer = (state: boolean, action: void) => boolean;
 
 const reducer: ToggleReducer = state => !state;
 
-const useForceUpdate: VoidFunctionCreator = () => (
-  useReducer(reducer, true)[1] as VoidFunction
-);
+const useForceUpdate: VoidFunctionCreator = () => {
+  const [, dispatch] = useReducer(reducer, true);
+  return dispatch as VoidFunction;
+};
 
 export default useForceUpdate;

--- a/src/use-force-update.ts
+++ b/src/use-force-update.ts
@@ -1,21 +1,13 @@
-import { useState } from 'react';
+import { useReducer } from 'react';
 
-interface VoidFunction {
-  (): void;
-}
+type VoidFunction = () => void
+type VoidFunctionCreator = () => VoidFunction;
+type ToggleReducer = (state: boolean, action: void) => boolean;
 
-interface VoidFunctionCreator {
-  (): VoidFunction;
-}
+const reducer: ToggleReducer = state => !state;
 
-const toggle = (state: boolean): boolean => !state;
-
-const useForceUpdate: VoidFunctionCreator = (): VoidFunction => {
-  const [ , setState ] = useState<boolean>(true);
-  const forceUpdate: VoidFunction = (): void => {
-    setState(toggle);
-  };
-  return forceUpdate;
-};
+const useForceUpdate: VoidFunctionCreator = () => (
+  useReducer(reducer, true)[1] as VoidFunction
+);
 
 export default useForceUpdate;

--- a/tests/use-force-update.spec.tsx
+++ b/tests/use-force-update.spec.tsx
@@ -31,4 +31,10 @@ describe('useForceUpdate', () => {
     expect(renders).to.equal(2);
   });
 
+  it('update function should return undefined', () => {
+    expect(forceUpdate()).to.be.undefined;
+    // @ts-ignore test with parameters :shrug:
+    expect(forceUpdate('anything')).to.be.undefined;
+  });
+
 });


### PR DESCRIPTION
follow up to #3 (perf optimization)

also: bundle size will be even smaller (not that is a concern :rofl:)

this avoids creating a new function on each render,
the identity value for the dispatch function stays stable.

[passing dispatcher down is encouraged](https://reactjs.org/docs/hooks-faq.html#how-to-avoid-passing-callbacks-down) because of "ref stability".

added some tests to guarantee void returns from function,
as I had to do some coercion. (dispatcher function is too specific)

this is *not* a breaking change, and compatible with both alpha and stable react.
(the alpha lacks the third argument to `useReducer`, this doesn't use it.)

---
**update**: regarding the other, [even shorter, proposal](https://github.com/CharlesStover/use-force-update/issues/2#issuecomment-437005556):
the reducer proposed here seems more "reliable" as the `setState` will always return `undefined`.

React may bail out in the future, [if it doesn't already](https://reactjs.org/docs/hooks-reference.html#bailing-out-of-a-state-update).

**update 2**: yeps, react broke the `() => useState()[1]`:
```diff
should update a component:

AssertionError: expected 1 to equal 2

-1
+2
```