### PR TITLE
useRef instead of useMemo

### DIFF
--- a/src/use-force-update.ts
+++ b/src/use-force-update.ts
@@ -1,21 +1,8 @@
-import { useMemo, useReducer } from 'react';
+import { useRef, useState } from 'react';
 
-type VoidFunction = () => void;
-
-const reducer = (state: boolean, _action: null): boolean => !state;
-
-const useForceUpdate = (): VoidFunction => {
-  const [ , dispatch] = useReducer<boolean, null>(reducer, true);
-
-  // Turn dispatch(required_parameter) into dispatch().
-  const memoizedDispatch = useMemo(
-    (): VoidFunction =>
-      (): void => {
-        dispatch(null);
-      },
-    [ dispatch ]
-  );
-  return memoizedDispatch;
-};
+function useForceUpdate() {
+  const setValue = useState(0)[1]
+  return useRef(() => setValue(v => ~v)).current
+}
 
 export default useForceUpdate;


### PR DESCRIPTION
This way it is shorter.  
Also this implementation does not rely on `useMemo` which according to documentation may decide to skip caching under certain circumstances in the future.