### PR TITLE
fix: unstable_batchedUpdates compatibility

### DIFF
--- a/src/use-force-update.ts
+++ b/src/use-force-update.ts
@@ -1,20 +1,6 @@
-import { useCallback, useReducer } from 'react';
+import { useReducer } from 'react';
 
-type VoidFunction = () => void;
-
-const reducer = (state: boolean, _action: null): boolean => !state;
-
-const useForceUpdate = (): VoidFunction => {
-  const [ , dispatch] = useReducer<boolean, null>(reducer, true);
-
-  // Turn dispatch(required_parameter) into dispatch().
-  const memoizedDispatch = useCallback(
-    (): void => {
-      dispatch(null);
-    },
-    [ dispatch ],
-  );
-  return memoizedDispatch;
-};
+const useForceUpdate = () =>
+  useReducer(() => ({}), {})[1] as (() => void);
 
 export default useForceUpdate;


### PR DESCRIPTION
This simplifies the implementation and prevents a bug when used with `unstable_batchedUpdates` (which wraps around every React-managed event listener).

For more info, see here: https://twitter.com/alecdotbiz/status/1142506184240521216